### PR TITLE
Reject false matches: require "status:" or "status," as a command prefix

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -35,7 +35,8 @@ function createBot(host, room, cb) {
     // is this a public message to me?  if so, let's
     // see if there's a handler that would like to respond
     // remove the room check
-    if (bot.nick.toLowerCase() == message.substr(0, bot.nick.length).toLowerCase()) {
+    if ((bot.nick.toLowerCase() == message.substr(0, bot.nick.length).toLowerCase())
+      && (message.substr(bot.nick.length, 1).match(/[:,]/)) ) {
       // chop off our name
       message = message.substr(bot.nick.length);
       // chop of typical chars that delimit our name from message


### PR DESCRIPTION
This avoids a false hit when someone says things like "statuses are
immutable" or "status codes are neat" in the channel. It also rejects a
space delimiter, like "status working on IRC bots", which I think is
probably ok.
